### PR TITLE
Refactor: handle route path including non-serial dynamic route variables

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -101,8 +101,6 @@ export class Router {
         paramNames.push(paramName);
         return "/([^\\/]+)";
       });
-    const matcher = new RegExp(regexpSource, "i");
-
-    return matcher;
+    return new RegExp(regexpSource, "i");
   };
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -75,7 +75,7 @@ export class Router {
 
   #createPathParams = (dynamicRouteVariables, pathVariables) => {
     return dynamicRouteVariables.reduce((pathParams, dynamicRouteVariable, index) => {
-      pathParams[dynamicRouteVariable] = decodeURIComponent(pathVariables[index] || "", dynamicRouteVariable);
+      pathParams[dynamicRouteVariable] = pathVariables[index];
       return pathParams;
     }, {});
   };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -81,21 +81,19 @@ export class Router {
   };
 
   #getMatchedPathVariables = (routePath, path) => {
-    const pathRegex = this.#compilePath(routePath);
+    const pathRegex = this.#createPathRegex(routePath);
     const pathVariables = path.match(pathRegex).slice(1);
     // if (!pathVariables) throw new Error("not supported path variable");
     // TODO: throw error when there's no matched params
     return pathVariables;
   };
 
-  #createPathRegex = (path) => new RegExp("^" + path.replace(/\//g, "\\/").replace(/:\w+/g, "(.+)") + "$");
-
   #getDynamicPathVariables = (path) => {
     const dynamicRouteVarRegex = new RegExp(/(?<=:)\w+/g);
     return path.match(dynamicRouteVarRegex);
   };
 
-  #compilePath = (path) => {
+  #createPathRegex = (path) => {
     const paramNames = [];
     const regexpSource =
       "^" +

--- a/src/router/index.test.js
+++ b/src/router/index.test.js
@@ -4,16 +4,19 @@ const page = "page";
 const page2 = "page2";
 const page3 = "page3";
 const page4 = "page4";
+const page5 = "page5";
 
 const path = "/article";
 const path2 = "/article/12";
 const path3 = "/article/dev/12";
 const path4 = "/article/tech/dev/12";
+const path5 = "/tech/dev/12/4";
 
 const routePath = "/article";
 const routePath2 = "/article/:id";
 const routePath3 = "/article/:category/:id";
 const routePath4 = "/article/:category/:subject/:id";
+const routePath5 = "/article-category/:title/12/:id";
 
 const routes = [
   {
@@ -31,6 +34,10 @@ const routes = [
   {
     path: routePath4,
     page: page4,
+  },
+  {
+    path: routePath5,
+    page: page5,
   },
 ];
 
@@ -66,5 +73,10 @@ describe("test getPathVariables", () => {
   test("test 3 multiple dynamic route path", () => {
     window.location = { pathname: path4 };
     expect(Router.getInstance().getPathVariables()).toEqual({ category: "tech", subject: "dev", id: "12" });
+  });
+
+  test("test non-serial dynamic route path", () => {
+    window.location = { pathname: path5 };
+    expect(Router.getInstance().getPathVariables()).toEqual({ id: "4", title: "dev" });
   });
 });


### PR DESCRIPTION
### Description

- **동적 라우팅 변수가 연속적으로 존재하지 않는 경우도 처리할 수 있도록 리팩토링**
  - ex) `/article/:category/blog/:id`
  - React-router matchPath()참고해 createPathRegex()가 반환하는 정규표현식 변경
    - "/"로 시작하지 않을 경우 추가
    - :로 시작하는 변수 자리에 다른 문자열이 대응할 수 있도록 변경: replace()의 두 번째 인자로 함수 전달
    - ex)`/article/:category/12/:id` => `^/article/([^\/]+)/12/([^\/]+)`
#### 기타
- **createPathParams() 리팩토링**
  - [기존] dynamicRouteVariables, pathVariables 배열을 각각 for문으로 순회하며 객체로 조합
  - [변경] Array.prototype.reduce() 사용
- **getMatchedPathVariables**
  - [기존] matchedParams.shift()해 첫번째 요소 제거
  - [변경] slice()사용