### PR TITLE
#67 Refactor: createQueryString not to use overlapped array

### DIFF
--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -27,10 +27,6 @@ export interface FetchRequest {
   handler?: ApiHandlers;
 }
 
-export interface PathParams {
-  [dynamicRouteVariable: string]: number | string | undefined | string[];
-}
-
-export interface ObjectParams {
-  [key: string]: number | string | undefined | string[];
+export interface SearchParams {
+  [key: string]: number | string | string[] | undefined;
 }

--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -28,5 +28,9 @@ export interface FetchRequest {
 }
 
 export interface PathParams {
-  [dynamicRouteVariable: string]: string | undefined | string[];
+  [dynamicRouteVariable: string]: number | string | undefined | string[];
+}
+
+export interface ObjectParams {
+  [key: string]: number | string | undefined | string[];
 }

--- a/src/utils/router/index.ts
+++ b/src/utils/router/index.ts
@@ -123,7 +123,7 @@ export class Router {
     return false;
   };
 
-  #createPathParams = (dynamicRouteVariables: RegExpMatchArray | null, pathVariables: string[] | undefined) => {
+  #createPathParams = (dynamicRouteVariables: RegExpMatchArray, pathVariables: string[] = []) => {
     return dynamicRouteVariables?.reduce((pathParams: SearchParams, dynamicRouteVariable, index) => {
       pathParams[dynamicRouteVariable] = pathVariables?.[index];
       return pathParams;
@@ -136,9 +136,11 @@ export class Router {
     return pathVariables;
   };
 
-  #getDynamicPathVariables = (path: string): RegExpMatchArray | null => {
+  #getDynamicPathVariables = (path: string): RegExpMatchArray => {
     const dynamicRouteVarRegex = new RegExp(/(?<=:)\w+/g);
-    return path.match(dynamicRouteVarRegex);
+    const matchedPath = path.match(dynamicRouteVarRegex);
+    if (!matchedPath) throw new Error("no matched path");
+    return matchedPath;
   };
 
   #createPathRegex = (path: string) => {

--- a/src/utils/router/index.ts
+++ b/src/utils/router/index.ts
@@ -1,4 +1,4 @@
-import { PathParams, Routes } from "./../interfaces/index";
+import { ObjectParams, PathParams, Routes } from "./../interfaces/index";
 export class Router {
   #$app;
   #routes: Routes;
@@ -82,24 +82,35 @@ export class Router {
   }
 
   #createQueryString(params: string | PathParams = "") {
-    const searchParams = new URLSearchParams(
-      typeof params === "string" || Array.isArray(params) || params instanceof URLSearchParams
-        ? params
-        : Object.keys(params).reduce((searchParams: string[][], key) => {
-            //has to rename searchParams
-            let value = params[key]; //to const
-            if (!value) return searchParams;
-
-            if (Array.isArray(value)) {
-              return searchParams.concat(value.map((searchParam) => [key, searchParam]));
-            } else {
-              return searchParams.concat([[key, value]]); //이중 배열
-            }
-          }, [])
-    );
+    let searchParams;
+    if (typeof params === "string" || Array.isArray(params) || params instanceof URLSearchParams) {
+      searchParams = new URLSearchParams(params);
+    } else {
+      searchParams = this.handleObjParams(params);
+    }
 
     return searchParams;
   }
+
+  handleObjParams = (params: ObjectParams) => {
+    const searchParams = new URLSearchParams();
+    const paramKeys = Object.keys(params);
+
+    paramKeys.forEach((paramKey) => {
+      const paramValue = params[paramKey];
+      if (!paramValue) return searchParams;
+
+      if (!Array.isArray(paramValue)) {
+        searchParams.append(paramKey, paramValue.toString());
+      } else {
+        paramValue.forEach((value) => {
+          searchParams.append(paramKey, value);
+        });
+      }
+    });
+
+    return searchParams;
+  };
 
   #checkDynamicRoutePath = (routePath: string, path: string): boolean => {
     if (routePath.includes(":")) {

--- a/src/utils/router/index.ts
+++ b/src/utils/router/index.ts
@@ -1,4 +1,4 @@
-import { ObjectParams, PathParams, Routes } from "./../interfaces/index";
+import { Routes, SearchParams } from "./../interfaces/index";
 export class Router {
   #$app;
   #routes: Routes;
@@ -72,8 +72,7 @@ export class Router {
       }
     }
 
-    const setSearchParams = (params: any) => {
-      //need to change
+    const setSearchParams = (params: SearchParams) => {
       const newSearchParams = this.#createSearchParams(params).toString();
       this.navigate("", newSearchParams);
     };
@@ -81,7 +80,7 @@ export class Router {
     return [searchParams, setSearchParams];
   }
 
-  #createSearchParams(params: string | PathParams = "") {
+  #createSearchParams(params: string | SearchParams = ""): URLSearchParams {
     let searchParams;
     if (typeof params === "string" || Array.isArray(params) || params instanceof URLSearchParams) {
       searchParams = new URLSearchParams(params);
@@ -92,7 +91,7 @@ export class Router {
     return searchParams;
   }
 
-  #handleObjectParams = (params: ObjectParams) => {
+  #handleObjectParams = (params: SearchParams) => {
     const searchParams = new URLSearchParams();
     const paramKeys = Object.keys(params);
 
@@ -125,7 +124,7 @@ export class Router {
   };
 
   #createPathParams = (dynamicRouteVariables: RegExpMatchArray | null, pathVariables: string[] | undefined) => {
-    return dynamicRouteVariables?.reduce((pathParams: PathParams, dynamicRouteVariable, index) => {
+    return dynamicRouteVariables?.reduce((pathParams: SearchParams, dynamicRouteVariable, index) => {
       pathParams[dynamicRouteVariable] = pathVariables?.[index];
       return pathParams;
     }, {});

--- a/src/utils/router/index.ts
+++ b/src/utils/router/index.ts
@@ -61,8 +61,8 @@ export class Router {
   };
 
   handleSearchParams(initParams = "") {
-    let searchParams = this.#createQueryString(initParams);
-    const currentSearchParams = this.#createQueryString(window.location.search);
+    let searchParams = this.#createSearchParams(initParams);
+    const currentSearchParams = this.#createSearchParams(window.location.search);
 
     for (let key of currentSearchParams.keys()) {
       if (!searchParams.has(key)) {
@@ -74,25 +74,25 @@ export class Router {
 
     const setSearchParams = (params: any) => {
       //need to change
-      const newSearchParams = this.#createQueryString(params).toString();
+      const newSearchParams = this.#createSearchParams(params).toString();
       this.navigate("", newSearchParams);
     };
 
     return [searchParams, setSearchParams];
   }
 
-  #createQueryString(params: string | PathParams = "") {
+  #createSearchParams(params: string | PathParams = "") {
     let searchParams;
     if (typeof params === "string" || Array.isArray(params) || params instanceof URLSearchParams) {
       searchParams = new URLSearchParams(params);
     } else {
-      searchParams = this.handleObjParams(params);
+      searchParams = this.#handleObjectParams(params);
     }
 
     return searchParams;
   }
 
-  handleObjParams = (params: ObjectParams) => {
+  #handleObjectParams = (params: ObjectParams) => {
     const searchParams = new URLSearchParams();
     const paramKeys = Object.keys(params);
 
@@ -107,6 +107,7 @@ export class Router {
           searchParams.append(paramKey, value);
         });
       }
+      return;
     });
 
     return searchParams;


### PR DESCRIPTION
### Description
#### createQueryString: 이중배열을 사용하고 있던 로직 변경
- 기존 이중배열을 사용했던 이유: 
  - new URLSearchParams()에 인자로 전달할 때, 
  동일한 키로 여러개의 값을 설정하기 위해서는 이중배열로 전달해주어야 했기 때문입니다. 
  *해당 로직은 react-router-dom의 createSearchParams()를 참고했습니다.

- 변경한 이유:
    - 굳이 이중배열을 만드는 대신 정의된 메서드를 사용하는 것으로 대체 가능
    - new URLSearchParams()의 인자로 전달하는 것보다는 메서드를 사용해 searchParams에 값을 추가하는 방식이 
    공식문서 상에도 더 잘 소개되어 있고, 더 이해하기 쉬운 코드일 거라고 생각했습니다.
    
#### type 리팩토링
  - 객체 내부의 key, value로 path variable 변수명/값을 사용하는 경우 SearchParams interface로 통일

#### 함수명 변경
- createQueryString => createSearchParams: string이 아닌 searchParams를 리턴하는 함수이므로 이름 변경
- handleObjectParams 분리: 로직이 길어져 객체 형태의 인자를 searchParams로 처리하는 함수로 분리

<br>

### Question
- SearchParams interface안에는 undefined도 포함되어 있는데, 
`pathParams[dynamicRouteVariable]` 가 undefined가 될 수도 있기 때문입니다.. 
이렇게 Interface에 undefined를 포함시키는 것보다는 아래 로직에서 처리해주는 게 좋을 것 같은데, 어떤 방법이 더 좋을까요? 
```ts
  #createPathParams = (dynamicRouteVariables: RegExpMatchArray | null, pathVariables: string[] | undefined) => {
    return dynamicRouteVariables?.reduce((pathParams: SearchParams, dynamicRouteVariable, index) => {
      pathParams[dynamicRouteVariable] = pathVariables?.[index];

      //Type 'string | undefined' is not assignable to type 'string | number | string[]'.
      //Type 'undefined' is not assignable to type 'string | number | string[]'.

      return pathParams;
    }, {});
  };
```
- 이전 처럼 new URLSearchParams()인자로 이중 배열을 전달해주는 방법보다 이렇게 리팩토링한 방식은 어떨까요?